### PR TITLE
Changed renewal to 30 days before expiry...

### DIFF
--- a/letsencrypt/hooks/OnDaemonRun.hook.php
+++ b/letsencrypt/hooks/OnDaemonRun.hook.php
@@ -83,7 +83,7 @@
 							$this->output('Valid until: ' . date('m/d/Y - H:i:s', $time), $indent = 3);
 							$this->output('In Days: ' . ((int) $days), $indent = 3);
 							
-							if($days <= 0.01) {
+							if($days <= 30) {
 								$this->output('Certificate will be runs out, renewing,...', $indent = 3);
 								
 								$register = $this->letsencrypt->register($domain->ac_user_vc, $domain->ac_email_vc);


### PR DESCRIPTION
...as recommended by Let's Encrypt: https://letsencrypt.org/docs/integration-guide/

"We recommend renewing certificates automatically when they have a third of their total lifetime left. For Let’s Encrypt’s current 90-day certificates, that means renewing 30 days before expiration."